### PR TITLE
Left factor several parsers

### DIFF
--- a/Prelude/Optional/toList
+++ b/Prelude/Optional/toList
@@ -4,7 +4,7 @@ Convert an `Optional` value into the equivalent `List`
 Examples:
 
 ```
-./toList Integer ([1] : Optional Integer) = [1] : List Integer
+./toList Integer ([1] : Optional Integer) = [1]
 
 ./toList Integer ([] : Optional Integer) = [] : List Integer
 ```

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -492,7 +492,7 @@ exprC embedded = exprC0
   where
     chain pA pOp op pB = noted (do
         a <- pA
-        try (do _ <- pOp <?> "operator"; b <- pB; return (op a b)) <|> pure a )
+        (do _ <- pOp <?> "operator"; b <- pB; return (op a b)) <|> pure a )
 
     exprC0 = chain  exprC1          (symbol "||") BoolOr       exprC0
     exprC1 = chain  exprC2          (symbol "+" ) NaturalPlus  exprC1

--- a/tests/Examples.hs
+++ b/tests/Examples.hs
@@ -998,7 +998,7 @@ _Optional_null_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _Optional_toList_0 :: TestTree
 _Optional_toList_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code "./Prelude/Optional/toList Integer ([1] : Optional Integer)"
-    Util.assertNormalizesTo e "[1] : List Integer" )
+    Util.assertNormalizesTo e "[1]" )
 
 _Optional_toList_1 :: TestTree
 _Optional_toList_1 = Test.Tasty.HUnit.testCase "Example #1" (do


### PR DESCRIPTION
This eliminates or narrows the scope of a large number of `try`s in the
parsing logic so that Dhall's parser does not need to backtrack as much.
The effect on performance for the example in #108 is minor at just 4%
(1.392 s → 1.340 s), however this change is still worth doing because
left factoring the grammar improves locality of parsing error messages

The changes included in this revision are:

* Reducing the scope of the `try` in `exprA4` to only backtrack until
  parsing the `arrow` symbol.  The parser can safely commit once the
  `arrow` is parsed
* Changing `exprB1` to only parse empty lists and optional values.
  Non-empty lists fall back to being parsed by `exprF` without the
  annotation.  This means that the parser can safely commit after
  parsing one list element
* Removing backtracking from `exprD`, which in turn requires enabling
  backtracking for the `exprIntegerLit` parser.  More generally,
  any primitive parser that shares a first character with an operator
  has to be wrapped in `try`. However, backtracking is cheap if it
  is limited to a single primitive parser
* Record types and literals are combined into a single non-backtracking
  parser
* Union types and literals are combined into a single non-backtracking
  parser

This also requires a small change to one of the Prelude examples and
tests.  This change causes a list to be now parsed without an
annotation, which in turn causes the result of normalization to not
include an annotation