### PR TITLE
Strip leading newline from multi-line strings

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -264,6 +264,7 @@ doubleSingleQuoteString embedded = do
 
     p0 = do
         _ <- Text.Parser.Char.string "''"
+        _ <- optional (Text.Parser.Char.char '\n')
         p1
 
     p1 =    p2

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -13,11 +13,13 @@ import qualified Test.Tasty.HUnit
 import qualified Util
 
 import Test.Tasty (TestTree)
+import Test.Tasty.HUnit ((@?=))
 
 regressionTests :: TestTree
 regressionTests =
     Test.Tasty.testGroup "regression tests"
         [ issue96
+        , issue126
         , unnamedFields
         , trailingSpaceAfterStringLiterals
         ]
@@ -54,6 +56,15 @@ issue96 = Test.Tasty.HUnit.testCase "Issue #96" (do
     -- Verify that parsing should not fail
     _ <- Util.code "\"bar'baz\""
     return () )
+
+issue126 :: TestTree
+issue126 = Test.Tasty.HUnit.testCase "Issue #126" (do
+    e <- Util.code
+        "''\n\
+        \  foo\n\
+        \  bar\n\
+        \''"
+    Util.normalize' e @?= "\"foo\\nbar\\n\"" )
 
 trailingSpaceAfterStringLiterals :: TestTree
 trailingSpaceAfterStringLiterals =


### PR DESCRIPTION
Fixes #126

This means that:

```haskell
''
  foo
  bar
''
```

... will now be treated as:

```haskell
"foo\nbar\n"
```

... and not:

```haskell
"\nfoo\nbar\n"
```

The goal of this is to match the behavior of Nix (and also for user
convenience)